### PR TITLE
Remove schedule dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ pytest >= 3.3.2
 pytest-cov >= 2.5.1
 python-dateutil >= 2.6.1
 requests >= 2.18.4
-schedule >= 0.5.0
 pyOpenSSL >= 17.5.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
                       'psutil >= 5.4.3',
                       'python-dateutil >= 2.6.1',
                       'requests >= 2.18.4',
-                      'schedule >= 0.5.0',
                       'pyOpenSSL >= 17.5.0'
                       ],
     use_scm_version=True,


### PR DESCRIPTION
It seems like the `schedule` package is not used at all. This PR removes this dependency.