### PR TITLE
Fix urllib3 proxy scheme failures

### DIFF
--- a/http_request_randomizer/requests/proxy/requestProxy.py
+++ b/http_request_randomizer/requests/proxy/requestProxy.py
@@ -111,7 +111,10 @@ class RequestProxy:
             self.logger.debug("Using headers: {0}".format(str(headers)))
             self.logger.debug("Using proxy: {0}".format(str(self.current_proxy)))
             request = requests.request(method, url, headers=headers, data=data, params=params, timeout=req_timeout,
-                    proxies={"http": self.current_proxy.get_address(), "https": self.current_proxy.get_address()})
+                    proxies={
+                        "http": "http://{0}".format(self.current_proxy.get_address()),
+                        "https": "https://{0}".format(self.current_proxy.get_address())
+                    })
             # Avoid HTTP request errors
             if request.status_code == 409:
                 raise ConnectionError("HTTP Response [409] - Possible Cloudflare DNS resolution error")


### PR DESCRIPTION
## Included in this PR
- Explicitly define url scheme for request proxies
  - This fixes `urllib3.exceptions.ProxySchemeUnknown: Not supported proxy scheme None` errors on at least python 3.9
  - This complies with the [python requests documentation on defining proxies](https://requests.readthedocs.io/en/master/user/advanced/#proxies)