### PR TITLE
Allowing log_level to be set during instantiation of RequestProxy (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ if __name__ == '__main__':
         time.sleep(10)
 ````
 
+### Changing log levels
+The `RequestProxy` constructor accepts an optional parameter of `log_level` that can be used to change the level of logging. By default, this is equal to 0, or NOTSET. The python logging levels are documented [here](https://docs.python.org/3/library/logging.html#logging-levels). You can either use integers or their equivalent constant in the logging module. (e.g. `logging.DEBUG`, `logging.ERROR`, etc)
+
 ## Documentation 
 
 [http-request-randomizer documentation](https://pgaref.com/HTTP_Request_Randomizer)

--- a/README.md
+++ b/README.md
@@ -93,13 +93,14 @@ To use **http-request-randomizer** as a library, include it in your requirements
 Then you can simply generate a proxied request using a method call:
 
 ````python
+import logging
 import time
 from http_request_randomizer.requests.proxy.requestProxy import RequestProxy
 
 if __name__ == '__main__':
 
     start = time.time()
-    req_proxy = RequestProxy()
+    req_proxy = RequestProxy(log_level=logging.ERROR)
     print("Initialization took: {0} sec".format((time.time() - start)))
     print("Size: {0}".format(len(req_proxy.get_proxy_list())))
     print("ALL = {0} ".format(list(map(lambda x: x.get_address(), req_proxy.get_proxy_list()))))

--- a/http_request_randomizer/__init__.py
+++ b/http_request_randomizer/__init__.py
@@ -1,6 +1,6 @@
 __author__ = 'pgaref'
 
-__version__ = '1.2.3'
+__version__ = '1.3.2'
 
 __title__ = 'http_request_randomizer'
 __description__ = 'A package using public proxies to randomise http requests'

--- a/http_request_randomizer/requests/proxy/requestProxy.py
+++ b/http_request_randomizer/requests/proxy/requestProxy.py
@@ -31,10 +31,10 @@ handler.setFormatter(formatter)
 
 
 class RequestProxy:
-    def __init__(self, web_proxy_list=[], sustain=False, timeout=5, protocol=Protocol.HTTP):
+    def __init__(self, web_proxy_list=[], sustain=False, timeout=5, protocol=Protocol.HTTP, log_level=0):
         self.logger = logging.getLogger()
         self.logger.addHandler(handler)
-        self.logger.setLevel(0)
+        self.logger.setLevel(log_level)
         self.userAgent = UserAgentManager(file=os.path.join(os.path.dirname(__file__), '../data/user_agents.txt'))
 
         #####


### PR DESCRIPTION
There is no current way to stop this from logging to the console with the way this was hard coded to log everything. You can't override the logging level of this module from a calling module because this overrides it whenever you instantiate a new instance of the class and things are logged during the `__init__` of the object.

This allows the person using this library to pass in an optional log level.